### PR TITLE
Feat/#3 kakao o auth: 카카오 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/mango/diary/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/mango/diary/auth/config/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.mango.diary.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        DefaultUriBuilderFactory defaultUriBuilderFactory = new DefaultUriBuilderFactory();
+        defaultUriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setUriTemplateHandler(defaultUriBuilderFactory);
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/mango/diary/auth/controller/OAuthController.java
+++ b/src/main/java/com/mango/diary/auth/controller/OAuthController.java
@@ -1,0 +1,34 @@
+package com.mango.diary.auth.controller;
+
+
+import com.mango.diary.auth.controller.dto.OAuthSignInRequest;
+import com.mango.diary.auth.controller.dto.SignInUriDTO;
+import com.mango.diary.auth.domain.KakaoUser;
+import com.mango.diary.auth.jwt.dto.TokenResponse;
+import com.mango.diary.auth.oauth.RestTemplateOAuthRequester;
+import com.mango.diary.auth.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/oauth")
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+    private final RestTemplateOAuthRequester restTemplateOAuthRequester;
+
+    @GetMapping("/kakao/sign-in-uri")
+    public ResponseEntity<SignInUriDTO> signInUri(
+            @RequestParam("redirect-uri") String redirectUri
+    ) {
+        return ResponseEntity.ok(oAuthService.signInUri(redirectUri));
+    }
+
+    @PostMapping("/kakao/sign-in")
+    public ResponseEntity<TokenResponse> signIn(@RequestBody OAuthSignInRequest request) {
+        KakaoUser kakaoUser = restTemplateOAuthRequester.signIn(request);
+        return ResponseEntity.ok(oAuthService.signIn(kakaoUser));
+    }
+}

--- a/src/main/java/com/mango/diary/auth/controller/dto/OAuthSignInRequest.java
+++ b/src/main/java/com/mango/diary/auth/controller/dto/OAuthSignInRequest.java
@@ -1,0 +1,7 @@
+package com.mango.diary.auth.controller.dto;
+
+public record OAuthSignInRequest(
+        String redirectUri,
+        String code
+) {
+}

--- a/src/main/java/com/mango/diary/auth/controller/dto/SignInUriDTO.java
+++ b/src/main/java/com/mango/diary/auth/controller/dto/SignInUriDTO.java
@@ -1,0 +1,6 @@
+package com.mango.diary.auth.controller.dto;
+
+public record SignInUriDTO(
+        String signInUri
+) {
+}

--- a/src/main/java/com/mango/diary/auth/domain/KakaoUser.java
+++ b/src/main/java/com/mango/diary/auth/domain/KakaoUser.java
@@ -1,0 +1,25 @@
+package com.mango.diary.auth.domain;
+
+import java.util.Map;
+
+public class KakaoUser implements OAuthUser {
+
+    private Long id;
+    private String userName;
+
+    public KakaoUser(Map<String, Object> attributes) {
+        this.id = (Long) attributes.get("id");
+        this.userName = (String) attributes.get("nickname");
+    }
+
+    @Override
+    public Long id() {
+        return id;
+    }
+
+    @Override
+    public String userName() {
+        return userName;
+    }
+
+}

--- a/src/main/java/com/mango/diary/auth/domain/OAuthUser.java
+++ b/src/main/java/com/mango/diary/auth/domain/OAuthUser.java
@@ -1,0 +1,6 @@
+package com.mango.diary.auth.domain;
+
+public interface OAuthUser {
+    Long id();
+    String userName();
+}

--- a/src/main/java/com/mango/diary/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/mango/diary/auth/exception/AuthErrorCode.java
@@ -14,6 +14,7 @@ public enum AuthErrorCode implements ErrorCode {
     VERIFICATION_INCOMPLETE(400, 1005, "이메일 인증이 완료되지 않았습니다."),
     INCORRECT_INPUT(400, 1006, "회원정보가 올바르지 않습니다."),
     ALREADY_SIGN_OUT(401, 1007, "이미 로그아웃 된 사용자입니다."),
+    INTERNAL_SERVER_ERROR(500, 1008, "서버 오류가 발생했습니다."),
     //---------------------------------------------------------------------------------------
     INVALID_TOKEN_TYPE(400, 2000, "토큰의 타입이 유효하지 않습니다."),
     EXPIRED_TOKEN(401, 2001,"토큰이 만료되었습니다."),
@@ -24,7 +25,14 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_TOKEN_FORMAT(401, 2007,"토큰의 형식이 유효하지 않습니다."),
     JWT_ERROR(401, 2008, "토큰 관련 오류가 발생했습니다."),
     REFRESH_TOKEN_NOT_FOUND(404, 2009, "리프레시 토큰을 찾을 수 없습니다."),
-    INVALID_REFRESH_TOKEN(400, 2010, "리프레시 토큰이 유효하지 않습니다."),;
+    INVALID_REFRESH_TOKEN(400, 2010, "리프레시 토큰이 유효하지 않습니다."),
+    KAKAO_UNAUTHORIZED(401, 4000, "카카오 인증 오류입니다."),
+    KAKAO_FORBIDDEN(403, 4001, "카카오 접근이 금지되었습니다."),
+    KAKAO_NOT_FOUND(404, 4002, "카카오 리소스를 찾을 수 없습니다."),
+    KAKAO_BAD_REQUEST(400, 4003, "카카오 잘못된 요청입니다."),
+    KAKAO_INTERNAL_SERVER_ERROR(500, 4004, "카카오 서버 오류가 발생했습니다."),
+    ;
+
 
     private final int statusCode;
     private final int exceptionCode;

--- a/src/main/java/com/mango/diary/auth/oauth/RestTemplateOAuthRequester.java
+++ b/src/main/java/com/mango/diary/auth/oauth/RestTemplateOAuthRequester.java
@@ -1,0 +1,144 @@
+package com.mango.diary.auth.oauth;
+
+import com.mango.diary.auth.controller.dto.OAuthSignInRequest;
+import com.mango.diary.auth.domain.KakaoUser;
+import com.mango.diary.auth.exception.AuthErrorCode;
+import com.mango.diary.auth.oauth.dto.OAuthTokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import com.mango.diary.auth.exception.AuthException;
+
+import java.net.URI;
+import java.util.Map;
+
+
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class RestTemplateOAuthRequester {
+
+    private static final String RESPONSE_TYPE = "response_type";
+    private static final String CLIENT_ID = "client_id";
+    private static final String REDIRECT_URI = "redirect_uri";
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String SCOPE = "scope";
+    private static final String CODE = "code";
+
+    @Value("${oauth2.provider.kakao.login-uri}")
+    private String KAKAO_LOGIN_URI;
+    @Value("${oauth2.provider.kakao.client-id}")
+    private String KAKAO_CLIENT_ID;
+    @Value("${oauth2.provider.kakao.token-uri}")
+    private String KAKAO_TOKEN_URI;
+    @Value("${oauth2.provider.kakao.info-uri}")
+    private String KAKAO_INFO_URI;
+
+    private final RestTemplate restTemplate;
+
+    public String signInUri(String redirectUri) {
+        return UriComponentsBuilder.fromUriString(KAKAO_LOGIN_URI)
+                .queryParam(CLIENT_ID, KAKAO_CLIENT_ID)
+                .queryParam(REDIRECT_URI, redirectUri)
+                .queryParam(RESPONSE_TYPE, CODE)
+                .build()
+                .toString();
+    }
+
+    public KakaoUser signIn(OAuthSignInRequest request) {
+        OAuthTokenResponse accessToken = getKakaoToken(request);
+        KakaoUser user = getKakaoUserInfo(accessToken);
+
+        return user;
+    }
+
+    private KakaoUser getKakaoUserInfo(OAuthTokenResponse accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken.accessToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        URI infoUri = URI.create(KAKAO_INFO_URI);
+        RequestEntity<?> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, infoUri);
+        Map<String, Object> response = requestUserAttributes(requestEntity);
+        log.info("response: {}", response);
+        return new KakaoUser(response);
+    }
+
+    private Map<String, Object> requestUserAttributes(RequestEntity<?> requestEntity) {
+        try {
+            ResponseEntity<Map<String, Object>> responseEntity = restTemplate.exchange(requestEntity, new ParameterizedTypeReference<>() {});
+            return responseEntity.getBody();
+        } catch (HttpClientErrorException e) {
+            HttpStatus statusCode = (HttpStatus) e.getStatusCode();
+            switch (statusCode) {
+                case UNAUTHORIZED:
+                    throw new AuthException(AuthErrorCode.KAKAO_UNAUTHORIZED);
+                case FORBIDDEN:
+                    throw new AuthException(AuthErrorCode.KAKAO_FORBIDDEN);
+                case NOT_FOUND:
+                    throw new AuthException(AuthErrorCode.KAKAO_NOT_FOUND);
+                case BAD_REQUEST:
+                    throw new AuthException(AuthErrorCode.KAKAO_BAD_REQUEST);
+                default:
+                    throw new AuthException(AuthErrorCode.KAKAO_INTERNAL_SERVER_ERROR);
+            }
+        } catch (ResourceAccessException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private OAuthTokenResponse getKakaoToken(OAuthSignInRequest signInRequest) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        URI tokenUri = getTokenUri(signInRequest);
+
+        return getoAuthTokenResponse(tokenUri, request);
+    }
+
+    private OAuthTokenResponse getoAuthTokenResponse(URI tokenUri, HttpEntity<MultiValueMap<String, String>> request) {
+        try {
+            return restTemplate.postForEntity(tokenUri, request, OAuthTokenResponse.class).getBody();
+        } catch (HttpClientErrorException e) {
+            HttpStatus statusCode = (HttpStatus) e.getStatusCode();
+            switch (statusCode) {
+                case UNAUTHORIZED:
+                    throw new AuthException(AuthErrorCode.KAKAO_UNAUTHORIZED);
+                case FORBIDDEN:
+                    throw new AuthException(AuthErrorCode.KAKAO_FORBIDDEN);
+                case NOT_FOUND:
+                    throw new AuthException(AuthErrorCode.KAKAO_NOT_FOUND);
+                case BAD_REQUEST:
+                    throw new AuthException(AuthErrorCode.KAKAO_BAD_REQUEST);
+                default:
+                    throw new AuthException(AuthErrorCode.KAKAO_INTERNAL_SERVER_ERROR);
+            }
+        } catch (ResourceAccessException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+    private URI getTokenUri(OAuthSignInRequest request) {
+        return UriComponentsBuilder.fromUriString(KAKAO_TOKEN_URI)
+                .queryParam(CODE, request.code())
+                .queryParam(GRANT_TYPE, "authorization_code")
+                .queryParam(REDIRECT_URI, request.redirectUri())
+                .queryParam(CLIENT_ID, KAKAO_CLIENT_ID)
+                .build()
+                .toUri();
+    }
+}

--- a/src/main/java/com/mango/diary/auth/oauth/dto/OAuthTokenResponse.java
+++ b/src/main/java/com/mango/diary/auth/oauth/dto/OAuthTokenResponse.java
@@ -1,0 +1,11 @@
+package com.mango.diary.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OAuthTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") Long expiresIn,
+        String scope,
+        @JsonProperty("token_type") String tokenType
+) {
+}

--- a/src/main/java/com/mango/diary/auth/service/OAuthService.java
+++ b/src/main/java/com/mango/diary/auth/service/OAuthService.java
@@ -1,0 +1,44 @@
+package com.mango.diary.auth.service;
+
+import com.mango.diary.auth.controller.dto.SignInUriDTO;
+import com.mango.diary.auth.domain.KakaoUser;
+import com.mango.diary.auth.domain.User;
+import com.mango.diary.auth.domain.UserStatus;
+import com.mango.diary.auth.jwt.JwtProvider;
+import com.mango.diary.auth.jwt.dto.TokenResponse;
+import com.mango.diary.auth.oauth.RestTemplateOAuthRequester;
+import com.mango.diary.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthService {
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    private final RestTemplateOAuthRequester restTemplateOAuthRequester;
+
+    public SignInUriDTO signInUri(String redirectUri) {
+        return new SignInUriDTO(restTemplateOAuthRequester.signInUri(redirectUri));
+    }
+
+    public TokenResponse signIn(KakaoUser kakaoUser) {
+        if(userRepository.existsByUserEmail(kakaoUser.id().toString())){
+            User user = userRepository.findByUserEmail(kakaoUser.id().toString()).get();
+            return jwtProvider.createTokens(user.getId());
+        }
+        User user = User.builder()
+                .userEmail(kakaoUser.id().toString())
+                .userName(kakaoUser.userName())
+                .password("kakao_user")
+                .status(UserStatus.ACTIVE)
+                .build();
+        userRepository.save(user);
+
+        return jwtProvider.createTokens(user.getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,11 @@ spring:
             enable: true
 jwt:
   secret: ${JWT_SECRET}
+
+oauth2:
+  provider:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID}
+      login-uri: ${KAKAO_LOGIN_URI}
+      token-uri: ${KAKAO_TOKEN_URI}
+      info-uri: ${KAKAO_INFO_URI}


### PR DESCRIPTION
## 요약
- 카카오 소셜 로그인 구현
## 변경 사항
- application.yml에 카카오 소셜 로그인 관련 정보 추가
- 카카오 소셜 로그인 관련 에러코드 추가
- KakaoUser 클래스 생성
- OAuthController 구현
- OAuthService 구현
- OAuthSignInRequest DTO 생성
- OAuthTokenResponse DTO 생성
- OAuthUser 인터페이스 생성
- RestTemplateConfig 생성
## 추가사항
- 예외처리는 현재 일부분만 되어있어 추후 추가 적용할 예정